### PR TITLE
Add links from multiple chat exports

### DIFF
--- a/src/commands/addCommand.ts
+++ b/src/commands/addCommand.ts
@@ -1,10 +1,10 @@
 import { CommandHandlerParams } from "../common"
 import { DB } from "../db"
 
-export function rebuildCommand(ctx: CommandHandlerParams): void {
+export function addCommand(ctx: CommandHandlerParams): void {
   if (ctx.chat.type != "private") return
   try {
-    console.log(`Got /rebuild from ${ctx.chat.username}`)
+    console.log(`Got /add from ${ctx.chat.username}`)
     DB.push("/admin/DB", {
       rebuilding: {
         inProgress: true,

--- a/src/commands/resetCommand.ts
+++ b/src/commands/resetCommand.ts
@@ -1,0 +1,11 @@
+import { CommandHandlerParams } from "../common"
+import { ADMIN_ID } from "../constants"
+import { DB } from "../db"
+
+export function resetCommand(ctx: CommandHandlerParams): void {
+  if (ctx.message.from.id === ADMIN_ID) {
+    console.log("Resetting db.")
+
+    DB.push("/links", [])
+  }
+}

--- a/src/rebuildFromHistory.ts
+++ b/src/rebuildFromHistory.ts
@@ -4,7 +4,7 @@ import { addNewLink } from "./db"
 /**
  * Ricostruisce il DB da un dump della chat di telegram
  */
-export function rebuildFromHistory(history: string): void {
+export function getLinksFromHistory(history: string): void {
   const root = parse(history)
   const historyElement = root.querySelector(".history")
   const historyNodes = historyElement.querySelectorAll(".message")


### PR DESCRIPTION
Usare `/reset` per resettare il DB e `/add` per aggiungere link da file di esportazione chat di Telegram.